### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.5](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.4...v0.3.5) - 2023-08-05
 
 ### Fixed
-- downloading too many components ([#59](https://github.com/bos-cli-rs/bos-cli-rs/pull/59))
+- Fixed `components download` command for accounts with 30+ components ([#59](https://github.com/bos-cli-rs/bos-cli-rs/pull/59))
 
 ## [0.3.4](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.3...v0.3.4) - 2023-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.4...v0.3.5) - 2023-08-05
+
+### Fixed
+- downloading too many components ([#59](https://github.com/bos-cli-rs/bos-cli-rs/pull/59))
+
 ## [0.3.4](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.3...v0.3.4) - 2023-06-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.4 -> 0.3.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.5](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.4...v0.3.5) - 2023-08-05

### Fixed
- downloading too many components ([#59](https://github.com/bos-cli-rs/bos-cli-rs/pull/59))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).