### PR TITLE
Save forked components data

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@ use color_eyre::eyre::{ContextCompat, WrapErr};
 use console::{style, Style};
 use futures::StreamExt;
 use glob::glob;
-use near_cli_rs::{common::CallResultExt};
+use near_cli_rs::common::CallResultExt;
 use near_primitives::types::AccountId;
 use serde::de::{Deserialize, Deserializer};
 use similar::{ChangeTag, TextDiff};
@@ -66,7 +66,8 @@ pub fn diff_code(old_code: &str, new_code: &str) -> Result<(), DiffCodeError> {
     Err(DiffCodeError)
 }
 
-pub fn get_local_components(account_id: Option<AccountId>
+pub fn get_local_components(
+    account_id: Option<AccountId>,
 ) -> color_eyre::eyre::Result<HashMap<String, crate::socialdb_types::SocialDbComponent>> {
     let mut components = HashMap::new();
 
@@ -98,15 +99,17 @@ pub fn get_local_components(account_id: Option<AccountId>
             if source_parts.0 != account_id.clone().unwrap().trim() {
                 let mut metadata_content_json = read_metadata_file(metadata_filepath.clone())?;
                 metadata_content_json.fork_of = Some(source.clone());
-                save_metadata_file(component_filepath, metadata_content_json).wrap_err_with(|| {
-                    format!(
-                        "Failed to update component metadata {}",
-                        metadata_filepath.display()
-                    )
-                })?;      
+                save_metadata_file(component_filepath, metadata_content_json).wrap_err_with(
+                    || {
+                        format!(
+                            "Failed to update component metadata {}",
+                            metadata_filepath.display()
+                        )
+                    },
+                )?;
             }
         }
-        
+
         let metadata = if let Ok(metadata_json) = std::fs::read_to_string(&metadata_filepath) {
             Some(serde_json::from_str(&metadata_json).wrap_err_with(|| {
                 format!(
@@ -126,24 +129,30 @@ pub fn get_local_components(account_id: Option<AccountId>
     Ok(components)
 }
 
-pub fn save_metadata_file(component_filepath: PathBuf, metadata_content_json: SocialDbComponentMetadata) -> color_eyre::eyre::Result<()> {
+pub fn save_metadata_file(
+    component_filepath: PathBuf,
+    metadata_content_json: SocialDbComponentMetadata,
+) -> color_eyre::eyre::Result<()> {
     let metadata = serde_json::to_string_pretty(&metadata_content_json).wrap_err_with(|| {
-                            format!("Failed to serialize component metadata for {}", component_filepath.display())
-                        })?;
-    let component_metadata_path =
-                    component_filepath.with_extension("metadata.json");
-    std::fs::write(&component_metadata_path, metadata.as_bytes())
-                .wrap_err_with(|| {
-                    format!(
-                        "Failed to save component metadata into {}",
-                        component_metadata_path.display()
-                    )
+        format!(
+            "Failed to serialize component metadata for {}",
+            component_filepath.display()
+        )
     })?;
-    
+    let component_metadata_path = component_filepath.with_extension("metadata.json");
+    std::fs::write(&component_metadata_path, metadata.as_bytes()).wrap_err_with(|| {
+        format!(
+            "Failed to save component metadata into {}",
+            component_metadata_path.display()
+        )
+    })?;
+
     Ok(())
 }
 
-pub fn read_metadata_file(metadata_filepath: PathBuf) -> color_eyre::eyre::Result<SocialDbComponentMetadata> {
+pub fn read_metadata_file(
+    metadata_filepath: PathBuf,
+) -> color_eyre::eyre::Result<SocialDbComponentMetadata> {
     if metadata_filepath.is_file() {
         let metadata_content = std::fs::read_to_string(&metadata_filepath).wrap_err_with(|| {
             format!(
@@ -151,15 +160,23 @@ pub fn read_metadata_file(metadata_filepath: PathBuf) -> color_eyre::eyre::Resul
                 metadata_filepath.display()
             )
         })?;
-        
-        let metadata_content_json: SocialDbComponentMetadata = serde_json::from_str(&metadata_content).wrap_err_with(|| {
-            format!(
-                "Failed to parse component metadata from {}",
-                metadata_filepath.display()
-            )})?;
+
+        let metadata_content_json: SocialDbComponentMetadata =
+            serde_json::from_str(&metadata_content).wrap_err_with(|| {
+                format!(
+                    "Failed to parse component metadata from {}",
+                    metadata_filepath.display()
+                )
+            })?;
         Ok(metadata_content_json)
     } else {
-        Ok(SocialDbComponentMetadata {description: None, image: None, name: None, tags: None, fork_of: None})
+        Ok(SocialDbComponentMetadata {
+            description: None,
+            image: None,
+            name: None,
+            tags: None,
+            fork_of: None,
+        })
     }
 }
 
@@ -175,7 +192,10 @@ pub fn read_bos_file() -> color_eyre::eyre::Result<HashMap<String, String>> {
         .map(|line| {
             let parts: Vec<&str> = line.splitn(2, '=').collect();
             if parts.len() != 2 {
-                Err(color_eyre::Report::msg(format!("Failed to read .bos file. Invalid line format: {}", line)))
+                Err(color_eyre::Report::msg(format!(
+                    "Failed to read .bos file. Invalid line format: {}",
+                    line
+                )))
             } else {
                 Ok((parts[0].trim().to_string(), parts[1].trim().to_string()))
             }

--- a/src/components/deploy/mod.rs
+++ b/src/components/deploy/mod.rs
@@ -42,7 +42,7 @@ impl DeployCmd {
     fn input_deploy_to_account_id(
         context: &near_cli_rs::GlobalContext,
     ) -> color_eyre::eyre::Result<Option<near_cli_rs::types::account_id::AccountId>> {
-        let components = crate::common::get_local_components()?;
+        let components = crate::common::get_local_components(None)?;
         println!(
             "\nThere are <{}> components in the current folder ready for deployment:",
             components.len()

--- a/src/components/deploy/sign_as.rs
+++ b/src/components/deploy/sign_as.rs
@@ -50,7 +50,7 @@ impl From<SignerContext> for near_cli_rs::commands::ActionContext {
                     receiver_id: near_social_account_id.clone(),
                     actions: vec![],
                 };
-                let local_components = crate::common::get_local_components()?;
+                let local_components = crate::common::get_local_components(Some(deploy_to_account_id.clone()))?;
                 if local_components.is_empty() {
                     println!("There are no components in the current ./src folder. Goodbye.");
                     return Ok(prepopulated_transaction);

--- a/src/components/diff/mod.rs
+++ b/src/components/diff/mod.rs
@@ -34,7 +34,8 @@ impl DiffCmdContext {
                             )
                         })?;
 
-                    let local_components = crate::common::get_local_components(Some(account_id.clone()))?;
+                    let local_components =
+                        crate::common::get_local_components(Some(account_id.clone()))?;
                     if local_components.is_empty() {
                         println!("There are no components in the current ./src folder. Goodbye.");
                         return Ok(());

--- a/src/components/diff/mod.rs
+++ b/src/components/diff/mod.rs
@@ -34,7 +34,7 @@ impl DiffCmdContext {
                             )
                         })?;
 
-                    let local_components = crate::common::get_local_components()?;
+                    let local_components = crate::common::get_local_components(Some(account_id.clone()))?;
                     if local_components.is_empty() {
                         println!("There are no components in the current ./src folder. Goodbye.");
                         return Ok(());

--- a/src/components/download/mod.rs
+++ b/src/components/download/mod.rs
@@ -40,11 +40,14 @@ impl DownloadCmdContext {
                         }
                     };
 
-                    let input_args = serde_json::to_string(&crate::socialdb_types::SocialDbQueryWithOptions {
-                        keys: vec![format!("{account_id}/widget/*")],
-                        options: Some(crate::socialdb_types::SocialDbQueryOptions{return_type: "BlockHeight".to_string() }),
-                    })
-                    .wrap_err("Internal error: could not serialize SocialDB input args")?;
+                    let input_args =
+                        serde_json::to_string(&crate::socialdb_types::SocialDbQueryWithOptions {
+                            keys: vec![format!("{account_id}/widget/*")],
+                            options: Some(crate::socialdb_types::SocialDbQueryOptions {
+                                return_type: "BlockHeight".to_string(),
+                            }),
+                        })
+                        .wrap_err("Internal error: could not serialize SocialDB input args")?;
 
                     let call_result = network_config
                         .json_rpc_client()
@@ -55,7 +58,8 @@ impl DownloadCmdContext {
                             near_primitives::types::Finality::Final.into(),
                         )
                         .wrap_err("Failed to fetch the components state from SocialDB")?;
-                    let keys: SocialDbKeysWithBlockHeights = call_result.parse_result_from_json()?;
+                    let keys: SocialDbKeysWithBlockHeights =
+                        call_result.parse_result_from_json()?;
 
                     let remote_social_account_components =
                         if let Some(account_components) = keys.accounts.get(&account_id) {
@@ -96,8 +100,15 @@ impl DownloadCmdContext {
                                     component_code_path.display()
                                 )
                             })?;
-                        let block_height = remote_social_account_components.components.get(component_name);
-                        let near_path = format!("{}/widget/{}@{}", account_id, component_name, block_height.unwrap());
+                        let block_height = remote_social_account_components
+                            .components
+                            .get(component_name);
+                        let near_path = format!(
+                            "{}/widget/{}@{}",
+                            account_id,
+                            component_name,
+                            block_height.unwrap()
+                        );
                         components_paths.insert(component_name, near_path);
                         if let Some(metadata) = component.metadata() {
                             let metadata =
@@ -118,9 +129,9 @@ impl DownloadCmdContext {
 
                     let meta_file_path = std::path::PathBuf::from("./src/.bos");
                     let meta_file_content: String = components_paths
-                                                .iter()
-                                                .map(|(key, value)| format!("{}={}\n", key, value))
-                                                .collect();
+                        .iter()
+                        .map(|(key, value)| format!("{}={}\n", key, value))
+                        .collect();
                     std::fs::write(meta_file_path.clone(), meta_file_content.as_bytes())?;
 
                     println!(
@@ -173,8 +184,10 @@ pub struct SocialDbAccountComponents {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SocialDbKeysWithBlockHeights {
     #[serde(flatten)]
-    pub accounts:
-        std::collections::HashMap<near_primitives::types::AccountId, SocialDbAccountComponentsWithBlockHeights>,
+    pub accounts: std::collections::HashMap<
+        near_primitives::types::AccountId,
+        SocialDbAccountComponentsWithBlockHeights,
+    >,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/src/socialdb_types.rs
+++ b/src/socialdb_types.rs
@@ -3,6 +3,18 @@ use std::collections::HashMap;
 pub type ComponentName = String;
 
 #[derive(Debug, Clone, serde::Serialize)]
+pub struct SocialDbQueryOptions {
+    pub return_type: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SocialDbQueryWithOptions {
+    pub keys: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<SocialDbQueryOptions>
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SocialDbQuery {
     pub keys: Vec<String>,
 }

--- a/src/socialdb_types.rs
+++ b/src/socialdb_types.rs
@@ -11,7 +11,7 @@ pub struct SocialDbQueryOptions {
 pub struct SocialDbQueryWithOptions {
     pub keys: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<SocialDbQueryOptions>
+    pub options: Option<SocialDbQueryOptions>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/src/socialdb_types.rs
+++ b/src/socialdb_types.rs
@@ -57,6 +57,8 @@ pub struct SocialDbComponentMetadata {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<HashMap<String, Option<String>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fork_of: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
This PR introduces saving the components fork source in the metadata. This is a requirement described in this issue: https://github.com/near/near-discovery/issues/341.

How it works:

* the `download` command has been changed so that it creates a `src/.bos` file with a map `ComponentLocalPath -> ComponentRemotePathWithBlockHeight`. Here is an example record:
`MetadataEditor=somecoolaccount.testnet/widget/MetadataEditor@146848179`
* the `deploy` command checks whether a component is going to be deployed to a different account than its source found in the `src/.bos` file. If it is different it means that is is a fork and a `*.metadata.json` file should be created/updated.