### PR TITLE
chore: release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.6...v0.3.7) - 2023-12-19
+
+### Added
+- New command to initialize a new BOS project ([#69](https://github.com/bos-cli-rs/bos-cli-rs/pull/69))
+- Added self-update ([#67](https://github.com/bos-cli-rs/bos-cli-rs/pull/67))
+
+### Fixed
+- Updated installation instructions ([#76](https://github.com/bos-cli-rs/bos-cli-rs/pull/76))
+
 ## [0.3.6](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.5...v0.3.6) - 2023-10-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.6 -> 0.3.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.7](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.6...v0.3.7) - 2023-12-19

### Added
- New command to initialize a new BOS project ([#69](https://github.com/bos-cli-rs/bos-cli-rs/pull/69))
- Added self-update ([#67](https://github.com/bos-cli-rs/bos-cli-rs/pull/67))

### Fixed
- Updated installation instructions ([#76](https://github.com/bos-cli-rs/bos-cli-rs/pull/76))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).