### PR TITLE
chore: release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.7...v0.3.8) - 2024-01-11
+
+### Other
+- Added automatic publishing to npmjs ([#81](https://github.com/bos-cli-rs/bos-cli-rs/pull/81))
+- Changed NearBalance to NearToken. ([#77](https://github.com/bos-cli-rs/bos-cli-rs/pull/77))
+
 ## [0.3.7](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.6...v0.3.7) - 2023-12-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.7 -> 0.3.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.8](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.7...v0.3.8) - 2024-01-11

### Other
- Added automatic publishing to npmjs ([#81](https://github.com/bos-cli-rs/bos-cli-rs/pull/81))
- Changed NearBalance to NearToken. ([#77](https://github.com/bos-cli-rs/bos-cli-rs/pull/77))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).