### PR TITLE
chore: release v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.9...v0.3.10) - 2024-01-16
+
+### Added
+- Updated new project template ot the latest version
+
 ## [0.3.9](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.8...v0.3.9) - 2024-01-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.9 -> 0.3.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.10](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.9...v0.3.10) - 2024-01-16

### Added
- Updated new project template ot the latest version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).