### PR TITLE
chore: release v0.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.10...v0.3.11) - 2024-01-23
+
+### Other
+- Upgraded NEAR crates to 0.20.0 release ([#88](https://github.com/bos-cli-rs/bos-cli-rs/pull/88))
+- Updated binary releases pipeline to use cargo-dist v0.7.2 (previously v0.1.0-prerelease.3)  ([#87](https://github.com/bos-cli-rs/bos-cli-rs/pull/87))
+- Added the documentation for `--social-db-folder` option in components subcommand ([#85](https://github.com/bos-cli-rs/bos-cli-rs/pull/85))
+
 ## [0.3.10](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.9...v0.3.10) - 2024-01-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.10"
+version = "0.3.11"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.10 -> 0.3.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.11](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.10...v0.3.11) - 2024-01-23

### Other
- Upgraded NEAR crates to 0.20.0 release ([#88](https://github.com/bos-cli-rs/bos-cli-rs/pull/88))
- Updated binary releases pipeline to use cargo-dist v0.7.2 (previously v0.1.0-prerelease.3)  ([#87](https://github.com/bos-cli-rs/bos-cli-rs/pull/87))
- Added the documentation for `--social-db-folder` option in components subcommand ([#85](https://github.com/bos-cli-rs/bos-cli-rs/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).