### PR TITLE
chore: release v0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.11...v0.3.12) - 2024-01-30
+
+### Other
+- Create releases using a private access token to trigger downstream workflows (publish-to-npm)
+
 ## [0.3.11](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.10...v0.3.11) - 2024-01-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.11"
+version = "0.3.12"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.11 -> 0.3.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.12](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.11...v0.3.12) - 2024-01-30

### Other
- Create releases using a private access token to trigger downstream workflows (publish-to-npm)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).