### PR TITLE
chore: release v0.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.13](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.12...v0.3.13) - 2024-02-03
+
+### Other
+- Updated binary releases pipeline to use cargo-dist v0.9.0 (previously v0.7.2) ([#91](https://github.com/bos-cli-rs/bos-cli-rs/pull/91))
+- Fixed NPM_PACKAGE_NAME configuration in publish-to-npm.yml
+- Enable manual triggering for publish-to-npm.yml
+
 ## [0.3.12](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.11...v0.3.12) - 2024-01-30
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.12"
+version = "0.3.13"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.12 -> 0.3.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.13](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.12...v0.3.13) - 2024-02-03

### Other
- Updated binary releases pipeline to use cargo-dist v0.9.0 (previously v0.7.2) ([#91](https://github.com/bos-cli-rs/bos-cli-rs/pull/91))
- Fixed NPM_PACKAGE_NAME configuration in publish-to-npm.yml
- Enable manual triggering for publish-to-npm.yml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).