### PR TITLE
chore: release v0.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.14](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.13...v0.3.14) - 2024-05-28
+
+### Added
+- Upgraded the new project template to fix multiple imports and exports in a single file and introduce Continuous Deployment workflows
+
+### Fixed
+- Fixed a syntax error in CI (publish-to-npm.yml)
+
 ## [0.3.13](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.12...v0.3.13) - 2024-02-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.13"
+version = "0.3.14"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.13 -> 0.3.14

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.14](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.13...v0.3.14) - 2024-05-28

### Added
- Upgraded the new project template to fix multiple imports and exports in a single file and introduce Continuous Deployment workflows

### Fixed
- Fixed a syntax error in CI (publish-to-npm.yml)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).