### PR TITLE
Assemble `component_name` using built-in PathBuf

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -73,7 +73,7 @@ pub fn get_local_components(
             .with_extension("")
             .components()
             .filter_map(|component| match component {
-                std::path::Component::Normal(text) => Some(text.to_str()?),
+                std::path::Component::Normal(text) => text.to_str(),
                 _ => None,
             })
             .collect::<Vec<_>>()

--- a/src/common.rs
+++ b/src/common.rs
@@ -73,12 +73,7 @@ pub fn get_local_components(
             .with_extension("")
             .components()
             .filter_map(|component| match component {
-                std::path::Component::Normal(text) => Some(text.to_str().wrap_err_with(|| {
-                    format!(
-                        "Component name cannot be presented as UTF-8: {}",
-                        component_filepath.display()
-                    )
-                }).ok()?),
+                std::path::Component::Normal(text) => Some(text.to_str()?),
                 _ => None,
             })
             .collect::<Vec<_>>()

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use color_eyre::eyre::{ContextCompat, WrapErr};
+use color_eyre::eyre::WrapErr;
 use console::{style, Style};
 use futures::StreamExt;
 use glob::glob;


### PR DESCRIPTION
Fixes #93 by implementing another mechanism to assemble component_name

### MacOS

#### Before
![image](https://github.com/bos-cli-rs/bos-cli-rs/assets/41162202/69a79b8b-2a49-43e0-b615-5ea97b7c4498)

#### After
![image](https://github.com/bos-cli-rs/bos-cli-rs/assets/41162202/39add898-4e2b-4fa9-b26d-a1f481c2e7e3)


### Windows

#### Before
![telegram-cloud-photo-size-2-5449370015024408401-y](https://github.com/bos-cli-rs/bos-cli-rs/assets/41162202/d70ac941-d10a-4701-9320-69be72b92110)

#### After
![telegram-cloud-photo-size-2-5449370015024408402-y](https://github.com/bos-cli-rs/bos-cli-rs/assets/41162202/29d3e801-2ad1-414e-af4b-674fb122e1a2)





