### PR TITLE
chore: release v0.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.15](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.14...v0.3.15) - 2024-06-21
+
+### Fixed
+- Brings support for deploying nested folders on Windows (account for \ path delimiter) ([#94](https://github.com/bos-cli-rs/bos-cli-rs/pull/94))
+- Updated the starter project template to fix links in `npm run dev`
+
 ## [0.3.14](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.13...v0.3.14) - 2024-05-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.14 -> 0.3.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.15](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.14...v0.3.15) - 2024-06-21

### Fixed
- Brings support for deploying nested folders on Windows (account for \ path delimiter) ([#94](https://github.com/bos-cli-rs/bos-cli-rs/pull/94))
- Updated the starter project template to fix links in `npm run dev`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).