### PR TITLE
chore: release v0.3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.15...v0.3.16) - 2024-08-21
+
+### Other
+- Updated near-* dependencies to the latest versions (nearcore crates 0.24.1 and near-cli-rs 0.14.1) ([#98](https://github.com/bos-cli-rs/bos-cli-rs/pull/98))
+- updated deps to 0.23 version ([#96](https://github.com/bos-cli-rs/bos-cli-rs/pull/96))
+
 ## [0.3.15](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.14...v0.3.15) - 2024-06-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.15"
+version = "0.3.16"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.15 -> 0.3.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.16](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.15...v0.3.16) - 2024-08-21

### Other
- Updated near-* dependencies to the latest versions (nearcore crates 0.24.1 and near-cli-rs 0.14.1) ([#98](https://github.com/bos-cli-rs/bos-cli-rs/pull/98))
- updated deps to 0.23 version ([#96](https://github.com/bos-cli-rs/bos-cli-rs/pull/96))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).