### PR TITLE
chore: release v0.3.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.17](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.16...v0.3.17) - 2024-09-03
+
+### Added
+- Added TEACH-ME mode (activate it with `bos --teach-me`) ([#101](https://github.com/bos-cli-rs/bos-cli-rs/pull/101))
+
+### Other
+- devcontainer and deployment e2e test ([#99](https://github.com/bos-cli-rs/bos-cli-rs/pull/99))
+
 ## [0.3.16](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.15...v0.3.16) - 2024-08-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.16"
+version = "0.3.17"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.16 -> 0.3.17

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.17](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.16...v0.3.17) - 2024-09-03

### Added
- Added TEACH-ME mode (activate it with `bos --teach-me`) ([#101](https://github.com/bos-cli-rs/bos-cli-rs/pull/101))

### Other
- devcontainer and deployment e2e test ([#99](https://github.com/bos-cli-rs/bos-cli-rs/pull/99))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).