### PR TITLE
chore: release v0.3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.18](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.17...v0.3.18) - 2024-11-19
+
+### Other
+
+- updates near-* dependencies to 0.27 release ([#104](https://github.com/bos-cli-rs/bos-cli-rs/pull/104))
+- Updated near-* dependencies to 0.26 release ([#102](https://github.com/bos-cli-rs/bos-cli-rs/pull/102))
+
 ## [0.3.17](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.16...v0.3.17) - 2024-09-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.17"
+version = "0.3.18"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.17 -> 0.3.18

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.18](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.17...v0.3.18) - 2024-11-19

### Other

- updates near-* dependencies to 0.27 release ([#104](https://github.com/bos-cli-rs/bos-cli-rs/pull/104))
- Updated near-* dependencies to 0.26 release ([#102](https://github.com/bos-cli-rs/bos-cli-rs/pull/102))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).