### PR TITLE
chore: release v0.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.20](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.19...v0.3.20) - 2024-12-20
+
+### Other
+
+- restored to default dist workflow config (#107)
+
 ## [0.3.19](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.18...v0.3.19) - 2024-12-19
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.3.19"
+version = "0.3.20"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `bos-cli`: 0.3.19 -> 0.3.20

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.20](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.19...v0.3.20) - 2024-12-20

### Other

- restored to default dist workflow config (#107)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).