### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.4.0...v0.4.1) - 2025-07-08
+
+### Other
+
+- Updates near-* dependencies to 0.30 release  ([#114](https://github.com/bos-cli-rs/bos-cli-rs/pull/114))
+- Replaced ubuntu-20.04 with ubuntu-22.04 for CI runners due to end-of-life support ([#112](https://github.com/bos-cli-rs/bos-cli-rs/pull/112))
+
 ## [0.4.0](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.3.19...v0.4.0) - 2025-03-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `bos-cli`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.4.0...v0.4.1) - 2025-07-08

### Other

- Updates near-* dependencies to 0.30 release  ([#114](https://github.com/bos-cli-rs/bos-cli-rs/pull/114))
- Replaced ubuntu-20.04 with ubuntu-22.04 for CI runners due to end-of-life support ([#112](https://github.com/bos-cli-rs/bos-cli-rs/pull/112))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).