### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.4.1...v0.4.2) - 2026-02-11
+
+### Other
+
+- Updated near-cli-rs crate to 0.23.6 release ([#115](https://github.com/bos-cli-rs/bos-cli-rs/pull/115))
+
 ## [0.4.1](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.4.0...v0.4.1) - 2025-07-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "bos-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bos-cli"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `bos-cli`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/bos-cli-rs/bos-cli-rs/compare/v0.4.1...v0.4.2) - 2026-02-11

### Other

- Updated near-cli-rs crate to 0.23.6 release ([#115](https://github.com/bos-cli-rs/bos-cli-rs/pull/115))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).